### PR TITLE
Use "contact" instead of "links" in fabric mod json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,7 +4,7 @@
   "version": "1.2.12",
   "name": "Harvest",
   "description": "Configurable right click crop harvesting ",
-  "links": {
+  "contact": {
     "homepage": "https://minecraft.curseforge.com/projects/simpleharvest",
     "issues": "https://github.com/TehNut/Harvest/issues",
     "sources": "https://github.com/TehNut/Harvest"


### PR DESCRIPTION
In addition to #28, this should make it conform to the [Fabric documentation](https://fabricmc.net/wiki/documentation:fabric_mod_json#metadata).